### PR TITLE
Update ratpack.groovy file for ratpack.groovy.Groovy changes

### DIFF
--- a/src/ratpack/ratpack.groovy
+++ b/src/ratpack/ratpack.groovy
@@ -1,11 +1,11 @@
 import ratpack.example.groovywebconsole.ReloadingThing
 import ratpack.example.groovywebconsole.ScriptExecutionModule
 import ratpack.example.groovywebconsole.ScriptExecutor
-import ratpack.groovy.RatpackScript
-import ratpack.groovy.Template
+import ratpack.groovy.templating.Template
 import ratpack.groovy.templating.TemplatingModule
+import static ratpack.groovy.Groovy.*
 
-RatpackScript.ratpack {
+ratpack {
 
     modules {
         register new ScriptExecutionModule()
@@ -14,7 +14,7 @@ RatpackScript.ratpack {
 
     handlers {
         get {
-            render Template.groovyTemplate("skin.html", title: "Groovy Web Console")
+            render groovyTemplate("skin.html", title: "Groovy Web Console")
         }
 
         post("execute") { ScriptExecutor scriptExecutor ->


### PR DESCRIPTION
Currently, the example app will fail to run with the following error

```
ratpack.groovy: 4: unable to resolve class ratpack.groovy.RatpackScript
 @ line 4, column 1.
   import ratpack.groovy.RatpackScript
   ^
```

And also

```
ratpack.groovy: 5: unable to resolve class ratpack.groovy.Template
 @ line 5, column 1.
   import ratpack.groovy.Template
   ^
```

It looks like some bits have been moving around (in a positive way). This pr ensures the sample is back in running order.
