### PR TITLE
Fix failing test (change the way reference to TestHttpClient is obtained...

### DIFF
--- a/src/test/groovy/ratpack/example/groovywebconsole/ScriptExecutionSpec.groovy
+++ b/src/test/groovy/ratpack/example/groovywebconsole/ScriptExecutionSpec.groovy
@@ -22,7 +22,7 @@ class ScriptExecutionSpec extends Specification {
 
         then:
         with(new JsonResponse()) {
-            outputText == "hello world\n"
+            outputText == "hello world\n".denormalize()
             executionResult == ""
             stacktraceText == ""
         }


### PR DESCRIPTION
Spec fails due to missing method exception on `LocalScriptApplicationUnderTest#httpClient()`. Getting the `TestHttpClient` via `TestHttpClients.testHttpClient(aut)` fixes the problem.

In addition, the "captures output" spec fails on Windows due to the use of Unix-specific line separator (\n). Denormalising the corresponding GString (with Groovy's `denormalize()` method) fixes the problem.
